### PR TITLE
Add option to use linear solver for banded matrix and document solver arguments

### DIFF
--- a/sunode/solver.py
+++ b/sunode/solver.py
@@ -252,6 +252,37 @@ class Solver:
             linear_solver="dense",
             linear_solver_kwargs=None,
         ):
+        """
+        Parameters
+        ----------
+        problem: sunode Problem
+        abstol: float, optional
+            Absolute tolerance (default is 1e-10).
+        reltol: float, optional
+            Relative tolerance (default is 1e-10).
+        sense_mode: {"simultaneous", "staggered"}, optional
+            Forward sensitivity method (see [this explanation in the SUNDIALS documentation][1]).
+        scaling_factors: numpy.ndarray, optional
+            Vector of positive scaling factors used for the sensitivity calculations.
+        constraints: numpy.ndarray, optional
+            Vector of inequality constraints for the solution. The length of the vector must correspond
+            to the number of states. See the SUNDIALS documentation for the [constraint options][2].
+        solver: {"BDF", "ADAMS"}, optional
+            Algorithm for solving the ODE (the default is ``"BDF"``).
+        linear_solver: {"dense", "dense_finitediff", "spgmr", "spgmr_finitediff", "band"}, optional
+            Type of linear solver to use (the default is "dense").
+            If linear_solver is ``"band"``, ``linear_solver_kwargs`` must contain ``lower_bandwidth``
+            and ``upper_bandwidth``, defining the lower and upper half-bandwidth of the banded matrix
+            (see the [SUNDIALS documentation][3] for details).
+        linear_solver_kwargs: dict, optional
+            Keyword arguments for the linear solver.
+
+        [1]: https://sundials.readthedocs.io/en/latest/idas/Mathematics_link.html#forward-sensitivity-methods
+        [2]: https://sundials.readthedocs.io/en/latest/cvode/Usage/index.html#c.CVodeSetConstraints
+        [3]: https://sundials.readthedocs.io/en/latest/sunmatrix/SUNMatrix_links.html#the-sunmatrix-band-module
+        """
+        if linear_solver_kwargs is None:
+            linear_solver_kwargs = {}
         self._problem = problem
         self._user_data = problem.make_user_data()
         self._constraints = constraints

--- a/sunode/test_solve.py
+++ b/sunode/test_solve.py
@@ -171,7 +171,11 @@ def test_linear_solver_kwarg():
         'b': 0.2
     }
     problem = SympyProblem(params, states, rhs, derivative_params=[])
-    linear_solver_opts = ["dense", "dense_finitediff", "spgmr_finitediff", "spgmr"]
+    linear_solver_opts = ["dense", "dense_finitediff", "spgmr_finitediff", "spgmr", "band"]
     for linear_solver in linear_solver_opts:
-        solver = Solver(problem, linear_solver=linear_solver)
+        if linear_solver == "band":
+            linear_solver_kwargs = {"upper_bandwidth": 1, "lower_bandwidth": 1}
+        else:
+            linear_solver_kwargs = {}
+        solver = Solver(problem, linear_solver=linear_solver, linear_solver_kwargs=linear_solver_kwargs)
         check_call_solve(solver, param_vals, None)


### PR DESCRIPTION
I added an option for another linear solver implemented in SUNDIALS that is specialized for banded matrices. When the right-hand-side function has a banded structure, using this linear solver can speed up the ODE solver considerably.

In addition, I started documenting the arguments of the Solver.

Any feedback on the changes (including the documentation and test) is very welcome. :-)