### PR TITLE
Fix issue resulting from pickling the solver several times

### DIFF
--- a/sunode/solver.py
+++ b/sunode/solver.py
@@ -311,6 +311,7 @@ class Solver:
             "_linear_solver_kwargs",
             "_sens_mode",
             "_solver_kind",
+            "_state_names",
         ]
 
         self._init_sundials()


### PR DESCRIPTION
I got an error when trying to sample a model using sunode with PyMC's SMC sampler. As far as I understand, the solver could not be pickled several times, because it lost the `_state_names` attribute. This change fixes the issue for me.